### PR TITLE
fix recipes to use new compressed names

### DIFF
--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/1x_to_1x_gravel.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/1x_to_1x_gravel.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:gravel_block_1x"
+      "item": "allthecompressed:gravel_1x"
   },
   "input": {
-      "item": "allthecompressed:cobblestone_block_1x"
+      "item": "allthecompressed:cobblestone_1x"
   },
   "energy": 4480,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/2x_to_2x_gravel.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/2x_to_2x_gravel.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:gravel_block_2x"
+      "item": "allthecompressed:gravel_2x"
   },
   "input": {
-      "item": "allthecompressed:cobblestone_block_2x"
+      "item": "allthecompressed:cobblestone_2x"
   },
   "energy": 5760,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/3x_to_3x_gravel.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/3x_to_3x_gravel.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:gravel_block_3x"
+      "item": "allthecompressed:gravel_3x"
   },
   "input": {
-      "item": "allthecompressed:cobblestone_block_3x"
+      "item": "allthecompressed:cobblestone_3x"
   },
   "energy": 7040,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/4x_to_4x_gravel.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/4x_to_4x_gravel.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:gravel_block_4x"
+      "item": "allthecompressed:gravel_4x"
   },
   "input": {
-      "item": "allthecompressed:cobblestone_block_4x"
+      "item": "allthecompressed:cobblestone_4x"
   },
   "energy": 8320,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/5x_to_5x_gravel.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/5x_to_5x_gravel.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:gravel_block_5x"
+      "item": "allthecompressed:gravel_5x"
   },
   "input": {
-      "item": "allthecompressed:cobblestone_block_5x"
+      "item": "allthecompressed:cobblestone_5x"
   },
   "energy": 9600,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/6x_to_6x_gravel.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/6x_to_6x_gravel.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:gravel_block_6x"
+      "item": "allthecompressed:gravel_6x"
   },
   "input": {
-      "item": "allthecompressed:cobblestone_block_6x"
+      "item": "allthecompressed:cobblestone_6x"
   },
   "energy": 10880,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/7x_to_7x_gravel.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/7x_to_7x_gravel.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:gravel_block_7x"
+      "item": "allthecompressed:gravel_7x"
   },
   "input": {
-      "item": "allthecompressed:cobblestone_block_7x"
+      "item": "allthecompressed:cobblestone_7x"
   },
   "energy": 12160,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/8x_to_8x_gravel.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/8x_to_8x_gravel.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:gravel_block_8x"
+      "item": "allthecompressed:gravel_8x"
   },
   "input": {
-      "item": "allthecompressed:cobblestone_block_8x"
+      "item": "allthecompressed:cobblestone_8x"
   },
   "energy": 13440,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/9x_to_9x_gravel.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/cobblestone/9x_to_9x_gravel.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:gravel_block_9x"
+      "item": "allthecompressed:gravel_9x"
   },
   "input": {
-      "item": "allthecompressed:cobblestone_block_9x"
+      "item": "allthecompressed:cobblestone_9x"
   },
   "energy": 14720,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/1x_to_1x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/1x_to_1x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_1x"
+      "item": "allthecompressed:sand_1x"
   },
   "input": {
-      "item": "allthecompressed:glass_block_1x"
+      "item": "allthecompressed:glass_1x"
   },
   "energy": 4480,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/2x_to_2x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/2x_to_2x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_2x"
+      "item": "allthecompressed:sand_2x"
   },
   "input": {
-      "item": "allthecompressed:glass_block_2x"
+      "item": "allthecompressed:glass_2x"
   },
   "energy": 5760,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/3x_to_3x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/3x_to_3x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_3x"
+      "item": "allthecompressed:sand_3x"
   },
   "input": {
-      "item": "allthecompressed:glass_block_3x"
+      "item": "allthecompressed:glass_3x"
   },
   "energy": 7040,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/4x_to_4x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/4x_to_4x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_4x"
+      "item": "allthecompressed:sand_4x"
   },
   "input": {
-      "item": "allthecompressed:glass_block_4x"
+      "item": "allthecompressed:glass_4x"
   },
   "energy": 8320,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/5x_to_5x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/5x_to_5x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_5x"
+      "item": "allthecompressed:sand_5x"
   },
   "input": {
-      "item": "allthecompressed:glass_block_5x"
+      "item": "allthecompressed:glass_5x"
   },
   "energy": 9600,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/6x_to_6x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/6x_to_6x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_6x"
+      "item": "allthecompressed:sand_6x"
   },
   "input": {
-      "item": "allthecompressed:glass_block_6x"
+      "item": "allthecompressed:glass_6x"
   },
   "energy": 10880,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/7x_to_7x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/7x_to_7x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_7x"
+      "item": "allthecompressed:sand_7x"
   },
   "input": {
-      "item": "allthecompressed:glass_block_7x"
+      "item": "allthecompressed:glass_7x"
   },
   "energy": 12160,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/8x_to_8x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/8x_to_8x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_8x"
+      "item": "allthecompressed:sand_8x"
   },
   "input": {
-      "item": "allthecompressed:glass_block_8x"
+      "item": "allthecompressed:glass_8x"
   },
   "energy": 13440,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/9x_to_9x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/glass/9x_to_9x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_9x"
+      "item": "allthecompressed:sand_9x"
   },
   "input": {
-      "item": "allthecompressed:glass_block_9x"
+      "item": "allthecompressed:glass_9x"
   },
   "energy": 14720,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/1x_to_1x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/1x_to_1x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_1x"
+      "item": "allthecompressed:sand_1x"
   },
   "input": {
-      "item": "allthecompressed:gravel_block_1x"
+      "item": "allthecompressed:gravel_1x"
   },
   "energy": 4480,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/2x_to_2x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/2x_to_2x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_2x"
+      "item": "allthecompressed:sand_2x"
   },
   "input": {
-      "item": "allthecompressed:gravel_block_2x"
+      "item": "allthecompressed:gravel_2x"
   },
   "energy": 5760,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/3x_to_3x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/3x_to_3x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_3x"
+      "item": "allthecompressed:sand_3x"
   },
   "input": {
-      "item": "allthecompressed:gravel_block_3x"
+      "item": "allthecompressed:gravel_3x"
   },
   "energy": 7040,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/4x_to_4x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/4x_to_4x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_4x"
+      "item": "allthecompressed:sand_4x"
   },
   "input": {
-      "item": "allthecompressed:gravel_block_4x"
+      "item": "allthecompressed:gravel_4x"
   },
   "energy": 8320,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/5x_to_5x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/5x_to_5x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_5x"
+      "item": "allthecompressed:sand_5x"
   },
   "input": {
-      "item": "allthecompressed:gravel_block_5x"
+      "item": "allthecompressed:gravel_5x"
   },
   "energy": 9600,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/6x_to_6x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/6x_to_6x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_6x"
+      "item": "allthecompressed:sand_6x"
   },
   "input": {
-      "item": "allthecompressed:gravel_block_6x"
+      "item": "allthecompressed:gravel_6x"
   },
   "energy": 10880,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/7x_to_7x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/7x_to_7x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_7x"
+      "item": "allthecompressed:sand_7x"
   },
   "input": {
-      "item": "allthecompressed:gravel_block_7x"
+      "item": "allthecompressed:gravel_7x"
   },
   "energy": 12160,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/8x_to_8x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/8x_to_8x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_8x"
+      "item": "allthecompressed:sand_8x"
   },
   "input": {
-      "item": "allthecompressed:gravel_block_8x"
+      "item": "allthecompressed:gravel_8x"
   },
   "energy": 13440,
   "conditions": [{

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/9x_to_9x_sand.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/allthecompressed/gravel/9x_to_9x_sand.json
@@ -2,10 +2,10 @@
   "type": "immersiveengineering:crusher",
   "secondaries": [],
   "result": {
-      "item": "allthecompressed:sand_block_9x"
+      "item": "allthecompressed:sand_9x"
   },
   "input": {
-      "item": "allthecompressed:gravel_block_9x"
+      "item": "allthecompressed:gravel_9x"
   },
   "energy": 14720,
   "conditions": [{

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/1x_to_1x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/1x_to_1x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:cobblestone_block_1x"
+          "item": "allthecompressed:cobblestone_1x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_1x"
+      "item": "allthecompressed:gravel_1x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/2x_to_2x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/2x_to_2x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:cobblestone_block_2x"
+          "item": "allthecompressed:cobblestone_2x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_2x"
+      "item": "allthecompressed:gravel_2x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/3x_to_3x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/3x_to_3x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:cobblestone_block_3x"
+          "item": "allthecompressed:cobblestone_3x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_3x"
+      "item": "allthecompressed:gravel_3x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/4x_to_4x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/4x_to_4x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:cobblestone_block_4x"
+          "item": "allthecompressed:cobblestone_4x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_4x"
+      "item": "allthecompressed:gravel_4x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/5x_to_5x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/5x_to_5x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:cobblestone_block_5x"
+          "item": "allthecompressed:cobblestone_5x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_5x"
+      "item": "allthecompressed:gravel_5x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/6x_to_6x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/6x_to_6x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:cobblestone_block_6x"
+          "item": "allthecompressed:cobblestone_6x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_6x"
+      "item": "allthecompressed:gravel_6x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/7x_to_7x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/7x_to_7x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:cobblestone_block_7x"
+          "item": "allthecompressed:cobblestone_7x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_7x"
+      "item": "allthecompressed:gravel_7x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/8x_to_8x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/8x_to_8x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:cobblestone_block_8x"
+          "item": "allthecompressed:cobblestone_8x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_8x"
+      "item": "allthecompressed:gravel_8x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/9x_to_9x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/cobblestone/9x_to_9x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:cobblestone_block_9x"
+          "item": "allthecompressed:cobblestone_9x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_9x"
+      "item": "allthecompressed:gravel_9x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/1x_to_1x_sand.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/1x_to_1x_sand.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:gravel_block_1x"
+          "item": "allthecompressed:gravel_1x"
       }
   },
   "output": {
-      "item": "allthecompressed:sand_block_1x"
+      "item": "allthecompressed:sand_1x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/2x_to_2x_sand.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/2x_to_2x_sand.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:gravel_block_2x"
+          "item": "allthecompressed:gravel_2x"
       }
   },
   "output": {
-      "item": "allthecompressed:sand_block_2x"
+      "item": "allthecompressed:sand_2x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/3x_to_3x_sand.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/3x_to_3x_sand.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:gravel_block_3x"
+          "item": "allthecompressed:gravel_3x"
       }
   },
   "output": {
-      "item": "allthecompressed:sand_block_3x"
+      "item": "allthecompressed:sand_3x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/4x_to_4x_sand.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/4x_to_4x_sand.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:gravel_block_4x"
+          "item": "allthecompressed:gravel_4x"
       }
   },
   "output": {
-      "item": "allthecompressed:sand_block_4x"
+      "item": "allthecompressed:sand_4x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/5x_to_5x_sand.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/5x_to_5x_sand.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:gravel_block_5x"
+          "item": "allthecompressed:gravel_5x"
       }
   },
   "output": {
-      "item": "allthecompressed:sand_block_5x"
+      "item": "allthecompressed:sand_5x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/6x_to_6x_sand.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/6x_to_6x_sand.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:gravel_block_6x"
+          "item": "allthecompressed:gravel_6x"
       }
   },
   "output": {
-      "item": "allthecompressed:sand_block_6x"
+      "item": "allthecompressed:sand_6x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/7x_to_7x_sand.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/7x_to_7x_sand.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:gravel_block_7x"
+          "item": "allthecompressed:gravel_7x"
       }
   },
   "output": {
-      "item": "allthecompressed:sand_block_7x"
+      "item": "allthecompressed:sand_7x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/8x_to_8x_sand.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/8x_to_8x_sand.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:gravel_block_8x"
+          "item": "allthecompressed:gravel_8x"
       }
   },
   "output": {
-      "item": "allthecompressed:sand_block_8x"
+      "item": "allthecompressed:sand_8x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/9x_to_9x_sand.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/gravel/9x_to_9x_sand.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:gravel_block_9x"
+          "item": "allthecompressed:gravel_9x"
       }
   },
   "output": {
-      "item": "allthecompressed:sand_block_9x"
+      "item": "allthecompressed:sand_9x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/1x_to_1x_cobblestone.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/1x_to_1x_cobblestone.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:stone_block_1x"
+          "item": "allthecompressed:stone_1x"
       }
   },
   "output": {
-      "item": "allthecompressed:cobblestone_block_1x"
+      "item": "allthecompressed:cobblestone_1x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/2x_to_2x_cobblestone.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/2x_to_2x_cobblestone.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:stone_block_2x"
+          "item": "allthecompressed:stone_2x"
       }
   },
   "output": {
-      "item": "allthecompressed:cobblestone_block_2x"
+      "item": "allthecompressed:cobblestone_2x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/3x_to_3x_cobblestone.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/3x_to_3x_cobblestone.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:stone_block_3x"
+          "item": "allthecompressed:stone_3x"
       }
   },
   "output": {
-      "item": "allthecompressed:cobblestone_block_3x"
+      "item": "allthecompressed:cobblestone_3x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/4x_to_4x_cobblestone.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/4x_to_4x_cobblestone.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:stone_block_4x"
+          "item": "allthecompressed:stone_4x"
       }
   },
   "output": {
-      "item": "allthecompressed:cobblestone_block_4x"
+      "item": "allthecompressed:cobblestone_4x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/5x_to_5x_cobblestone.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/5x_to_5x_cobblestone.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:stone_block_5x"
+          "item": "allthecompressed:stone_5x"
       }
   },
   "output": {
-      "item": "allthecompressed:cobblestone_block_5x"
+      "item": "allthecompressed:cobblestone_5x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/6x_to_6x_cobblestone.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/6x_to_6x_cobblestone.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:stone_block_6x"
+          "item": "allthecompressed:stone_6x"
       }
   },
   "output": {
-      "item": "allthecompressed:cobblestone_block_6x"
+      "item": "allthecompressed:cobblestone_6x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/7x_to_7x_cobblestone.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/7x_to_7x_cobblestone.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:stone_block_7x"
+          "item": "allthecompressed:stone_7x"
       }
   },
   "output": {
-      "item": "allthecompressed:cobblestone_block_7x"
+      "item": "allthecompressed:cobblestone_7x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/8x_to_8x_cobblestone.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/8x_to_8x_cobblestone.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:stone_block_8x"
+          "item": "allthecompressed:stone_8x"
       }
   },
   "output": {
-      "item": "allthecompressed:cobblestone_block_8x"
+      "item": "allthecompressed:cobblestone_8x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/9x_to_9x_cobblestone.json
+++ b/src/main/resources/data/mekanism/recipes/crushing/allthecompressed/stone/9x_to_9x_cobblestone.json
@@ -2,11 +2,11 @@
   "type": "mekanism:crushing",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:stone_block_9x"
+          "item": "allthecompressed:stone_9x"
       }
   },
   "output": {
-      "item": "allthecompressed:cobblestone_block_9x"
+      "item": "allthecompressed:cobblestone_9x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/1x_to_1x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/1x_to_1x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:red_sand_block_1x"
+          "item": "allthecompressed:red_sand_1x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_1x"
+      "item": "allthecompressed:gravel_1x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/2x_to_2x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/2x_to_2x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:red_sand_block_3x"
+          "item": "allthecompressed:red_sand_3x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_3x"
+      "item": "allthecompressed:gravel_3x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/3x_to_3x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/3x_to_3x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:red_sand_block_3x"
+          "item": "allthecompressed:red_sand_3x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_3x"
+      "item": "allthecompressed:gravel_3x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/4x_to_4x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/4x_to_4x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:red_sand_block_4x"
+          "item": "allthecompressed:red_sand_4x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_4x"
+      "item": "allthecompressed:gravel_4x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/5x_to_5x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/5x_to_5x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:red_sand_block_5x"
+          "item": "allthecompressed:red_sand_5x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_5x"
+      "item": "allthecompressed:gravel_5x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/6x_to_6x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/6x_to_6x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:red_sand_block_6x"
+          "item": "allthecompressed:red_sand_6x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_6x"
+      "item": "allthecompressed:gravel_6x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/7x_to_7x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/7x_to_7x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:red_sand_block_7x"
+          "item": "allthecompressed:red_sand_7x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_7x"
+      "item": "allthecompressed:gravel_7x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/8x_to_8x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/8x_to_8x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:red_sand_block_8x"
+          "item": "allthecompressed:red_sand_8x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_8x"
+      "item": "allthecompressed:gravel_8x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/9x_to_9x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/red_sand/9x_to_9x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:red_sand_block_9x"
+          "item": "allthecompressed:red_sand_9x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_9x"
+      "item": "allthecompressed:gravel_9x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/1x_to_1x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/1x_to_1x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:sand_block_1x"
+          "item": "allthecompressed:sand_1x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_1x"
+      "item": "allthecompressed:gravel_1x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/2x_to_2x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/2x_to_2x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:sand_block_2x"
+          "item": "allthecompressed:sand_2x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_2x"
+      "item": "allthecompressed:gravel_2x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/3x_to_3x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/3x_to_3x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:sand_block_3x"
+          "item": "allthecompressed:sand_3x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_3x"
+      "item": "allthecompressed:gravel_3x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/4x_to_4x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/4x_to_4x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:sand_block_4x"
+          "item": "allthecompressed:sand_4x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_4x"
+      "item": "allthecompressed:gravel_4x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/5x_to_5x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/5x_to_5x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:sand_block_5x"
+          "item": "allthecompressed:sand_5x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_5x"
+      "item": "allthecompressed:gravel_5x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/6x_to_6x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/6x_to_6x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:sand_block_6x"
+          "item": "allthecompressed:sand_6x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_6x"
+      "item": "allthecompressed:gravel_6x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/7x_to_7x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/7x_to_7x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:sand_block_7x"
+          "item": "allthecompressed:sand_7x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_7x"
+      "item": "allthecompressed:gravel_7x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/8x_to_8x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/8x_to_8x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:sand_block_8x"
+          "item": "allthecompressed:sand_8x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_8x"
+      "item": "allthecompressed:gravel_8x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/9x_to_9x_gravel.json
+++ b/src/main/resources/data/mekanism/recipes/enriching/allthecompressed/sand/9x_to_9x_gravel.json
@@ -2,11 +2,11 @@
   "type": "mekanism:enriching",
   "input": {
       "ingredient": {
-          "item": "allthecompressed:sand_block_9x"
+          "item": "allthecompressed:sand_9x"
       }
   },
   "output": {
-      "item": "allthecompressed:gravel_block_9x"
+      "item": "allthecompressed:gravel_9x"
   },
   "conditions": [{
       "type": "forge:and",

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/1x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/1x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:red_sand_block_1x",
+    "item": "allthecompressed:red_sand_1x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_1x"
+    "item": "allthecompressed:glass_1x"
   },
   "energy": 240000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/2x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/2x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:red_sand_block_2x",
+    "item": "allthecompressed:red_sand_2x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_2x"
+    "item": "allthecompressed:glass_2x"
   },
   "energy": 480000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/3x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/3x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:red_sand_block_3x",
+    "item": "allthecompressed:red_sand_3x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_3x"
+    "item": "allthecompressed:glass_3x"
   },
   "energy": 720000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/4x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/4x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:red_sand_block_4x",
+    "item": "allthecompressed:red_sand_4x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_4x"
+    "item": "allthecompressed:glass_4x"
   },
   "energy": 960000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/5x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/5x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:red_sand_block_5x",
+    "item": "allthecompressed:red_sand_5x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_5x"
+    "item": "allthecompressed:glass_5x"
   },
   "energy": 1200000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/6x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/6x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:red_sand_block_6x",
+    "item": "allthecompressed:red_sand_6x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_6x"
+    "item": "allthecompressed:glass_6x"
   },
   "energy": 1440000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/7x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/7x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:red_sand_block_7x",
+    "item": "allthecompressed:red_sand_7x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_7x"
+    "item": "allthecompressed:glass_7x"
   },
   "energy": 1680000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/8x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/8x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:red_sand_block_8x",
+    "item": "allthecompressed:red_sand_8x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_8x"
+    "item": "allthecompressed:glass_8x"
   },
   "energy": 2160000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/9x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/red_sand/9x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:red_sand_block_9x",
+    "item": "allthecompressed:red_sand_9x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_9x"
+    "item": "allthecompressed:glass_9x"
   },
   "energy": 2400000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/1x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/1x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:sand_block_1x",
+    "item": "allthecompressed:sand_1x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_1x"
+    "item": "allthecompressed:glass_1x"
   },
   "energy": 240000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/2x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/2x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:sand_block_2x",
+    "item": "allthecompressed:sand_2x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_2x"
+    "item": "allthecompressed:glass_2x"
   },
   "energy": 480000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/3x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/3x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:sand_block_3x",
+    "item": "allthecompressed:sand_3x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_3x"
+    "item": "allthecompressed:glass_3x"
   },
   "energy": 720000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/4x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/4x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:sand_block_4x",
+    "item": "allthecompressed:sand_4x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_4x"
+    "item": "allthecompressed:glass_4x"
   },
   "energy": 960000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/5x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/5x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:sand_block_5x",
+    "item": "allthecompressed:sand_5x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_5x"
+    "item": "allthecompressed:glass_5x"
   },
   "energy": 1200000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/6x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/6x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:sand_block_6x",
+    "item": "allthecompressed:sand_6x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_6x"
+    "item": "allthecompressed:glass_6x"
   },
   "energy": 1440000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/7x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/7x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:sand_block_7x",
+    "item": "allthecompressed:sand_7x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_7x"
+    "item": "allthecompressed:glass_7x"
   },
   "energy": 1680000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/8x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/8x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:sand_block_8x",
+    "item": "allthecompressed:sand_8x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_8x"
+    "item": "allthecompressed:glass_8x"
   },
   "energy": 2160000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/9x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/glass/sand/9x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:sand_block_9x",
+    "item": "allthecompressed:sand_9x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:glass_block_9x"
+    "item": "allthecompressed:glass_9x"
   },
   "energy": 2400000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/1x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/1x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobblestone_block_1x",
+    "item": "allthecompressed:cobblestone_1x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:stone_block_1x"
+    "item": "allthecompressed:stone_1x"
   },
   "energy": 240000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/2x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/2x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobblestone_block_2x",
+    "item": "allthecompressed:cobblestone_2x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:stone_block_2x"
+    "item": "allthecompressed:stone_2x"
   },
   "energy": 480000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/3x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/3x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobblestone_block_3x",
+    "item": "allthecompressed:cobblestone_3x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:stone_block_3x"
+    "item": "allthecompressed:stone_3x"
   },
   "energy": 720000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/4x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/4x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobblestone_block_4x",
+    "item": "allthecompressed:cobblestone_4x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:stone_block_4x"
+    "item": "allthecompressed:stone_4x"
   },
   "energy": 960000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/5x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/5x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobblestone_block_5x",
+    "item": "allthecompressed:cobblestone_5x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:stone_block_5x"
+    "item": "allthecompressed:stone_5x"
   },
   "energy": 1200000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/6x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/6x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobblestone_block_6x",
+    "item": "allthecompressed:cobblestone_6x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:stone_block_6x"
+    "item": "allthecompressed:stone_6x"
   },
   "energy": 1440000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/7x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/7x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobblestone_block_7x",
+    "item": "allthecompressed:cobblestone_7x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:stone_block_7x"
+    "item": "allthecompressed:stone_7x"
   },
   "energy": 1680000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/8x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/8x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobblestone_block_8x",
+    "item": "allthecompressed:cobblestone_8x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:stone_block_8x"
+    "item": "allthecompressed:stone_8x"
   },
   "energy": 2160000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/9x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/cobblestone/9x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobblestone_block_9x",
+    "item": "allthecompressed:cobblestone_9x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:stone_block_9x"
+    "item": "allthecompressed:stone_9x"
   },
   "energy": 2400000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/1x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/1x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobbled_deepslate_block_1x",
+    "item": "allthecompressed:cobbled_deepslate_1x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:deepslate_block_1x"
+    "item": "allthecompressed:deepslate_1x"
   },
   "energy": 240000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/2x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/2x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobbled_deepslate_block_2x",
+    "item": "allthecompressed:cobbled_deepslate_2x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:deepslate_block_2x"
+    "item": "allthecompressed:deepslate_2x"
   },
   "energy": 480000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/3x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/3x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobbled_deepslate_block_3x",
+    "item": "allthecompressed:cobbled_deepslate_3x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:deepslate_block_3x"
+    "item": "allthecompressed:deepslate_3x"
   },
   "energy": 720000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/4x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/4x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobbled_deepslate_block_4x",
+    "item": "allthecompressed:cobbled_deepslate_4x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:deepslate_block_4x"
+    "item": "allthecompressed:deepslate_4x"
   },
   "energy": 960000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/5x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/5x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobbled_deepslate_block_5x",
+    "item": "allthecompressed:cobbled_deepslate_5x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:deepslate_block_5x"
+    "item": "allthecompressed:deepslate_5x"
   },
   "energy": 1200000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/6x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/6x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobbled_deepslate_block_6x",
+    "item": "allthecompressed:cobbled_deepslate_6x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:deepslate_block_6x"
+    "item": "allthecompressed:deepslate_6x"
   },
   "energy": 1440000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/7x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/7x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobbled_deepslate_block_7x",
+    "item": "allthecompressed:cobbled_deepslate_7x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:deepslate_block_7x"
+    "item": "allthecompressed:deepslate_7x"
   },
   "energy": 1680000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/8x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/8x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobbled_deepslate_block_8x",
+    "item": "allthecompressed:cobbled_deepslate_8x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:deepslate_block_8x"
+    "item": "allthecompressed:deepslate_8x"
   },
   "energy": 2160000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/9x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/stone/deepslate/9x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:cobbled_deepslate_block_9x",
+    "item": "allthecompressed:cobbled_deepslate_9x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:deepslate_block_9x"
+    "item": "allthecompressed:deepslate_9x"
   },
   "energy": 2400000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/1x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/1x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:clay_block_1x",
+    "item": "allthecompressed:clay_1x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:terracotta_block_1x"
+    "item": "allthecompressed:terracotta_1x"
   },
   "energy": 240000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/2x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/2x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:clay_block_2x",
+    "item": "allthecompressed:clay_2x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:terracotta_block_2x"
+    "item": "allthecompressed:terracotta_2x"
   },
   "energy": 480000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/3x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/3x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:clay_block_3x",
+    "item": "allthecompressed:clay_3x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:terracotta_block_3x"
+    "item": "allthecompressed:terracotta_3x"
   },
   "energy": 720000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/4x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/4x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:clay_block_4x",
+    "item": "allthecompressed:clay_4x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:terracotta_block_4x"
+    "item": "allthecompressed:terracotta_4x"
   },
   "energy": 960000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/5x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/5x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:clay_block_5x",
+    "item": "allthecompressed:clay_5x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:terracotta_block_5x"
+    "item": "allthecompressed:terracotta_5x"
   },
   "energy": 1200000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/6x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/6x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:clay_block_6x",
+    "item": "allthecompressed:clay_6x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:terracotta_block_6x"
+    "item": "allthecompressed:terracotta_6x"
   },
   "energy": 1440000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/7x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/7x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:clay_block_7x",
+    "item": "allthecompressed:clay_7x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:terracotta_block_7x"
+    "item": "allthecompressed:terracotta_7x"
   },
   "energy": 1680000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/8x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/8x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:clay_block_8x",
+    "item": "allthecompressed:clay_8x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:terracotta_block_8x"
+    "item": "allthecompressed:terracotta_8x"
   },
   "energy": 2160000,
   "conditions": [

--- a/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/9x.json
+++ b/src/main/resources/data/thermal/recipes/furnace/allthecompressed/terracotta/9x.json
@@ -1,11 +1,11 @@
 {
   "type": "thermal:furnace",
   "ingredient": {
-    "item": "allthecompressed:clay_block_9x",
+    "item": "allthecompressed:clay_9x",
     "count": 1
   },
   "result": {
-    "item": "allthecompressed:terracotta_block_9x"
+    "item": "allthecompressed:terracotta_9x"
   },
   "energy": 2400000,
   "conditions": [


### PR DESCRIPTION
Currently when loading into a world with Mekanism on 1.20.1 you'll see many recipe parsing errors due to recipes using the old \_block\_ names for sand/cobble/gravel/stone compressed variants

This just updates those files to use the correct names

Note - this does not rectify the compressed blaze rod to compressed blazing crystal Powah recipe, as it looks like the compressed blaze rod block may have been removed, and I didn't want to take the liberty of deleting a file
```[WARN] Error parsing recipe powah:energizing/allthecompressed/blazing_crystal/3x[powah:energizing]: {"type":"powah:energizing","ingredients":[{"item":"allthecompressed:blaze_rod_block_3x"}],"energy":590490000,"result":{"item":"allthecompressed:blazing_crystal_block_3x"},"conditions":[{"type":"forge:mod_loaded","modid":"powah"}]}:```