### PR TITLE
add en_AU and en_GB translations

### DIFF
--- a/src/main/resources/assets/allthecompressed/lang/en_au.json
+++ b/src/main/resources/assets/allthecompressed/lang/en_au.json
@@ -1,0 +1,11 @@
+{
+  "block.allthecompressed.aluminum_block_1x": "Aluminium Block 1x",
+  "block.allthecompressed.aluminum_block_2x": "Aluminium Block 2x",
+  "block.allthecompressed.aluminum_block_3x": "Aluminium Block 3x",
+  "block.allthecompressed.aluminum_block_4x": "Aluminium Block 4x",
+  "block.allthecompressed.aluminum_block_5x": "Aluminium Block 5x",
+  "block.allthecompressed.aluminum_block_6x": "Aluminium Block 6x",
+  "block.allthecompressed.aluminum_block_7x": "Aluminium Block 7x",
+  "block.allthecompressed.aluminum_block_8x": "Aluminium Block 8x",
+  "block.allthecompressed.aluminum_block_9x": "Aluminium Block 9x"
+}

--- a/src/main/resources/assets/allthecompressed/lang/en_gb.json
+++ b/src/main/resources/assets/allthecompressed/lang/en_gb.json
@@ -1,0 +1,11 @@
+{
+  "block.allthecompressed.aluminum_block_1x": "Aluminium Block 1x",
+  "block.allthecompressed.aluminum_block_2x": "Aluminium Block 2x",
+  "block.allthecompressed.aluminum_block_3x": "Aluminium Block 3x",
+  "block.allthecompressed.aluminum_block_4x": "Aluminium Block 4x",
+  "block.allthecompressed.aluminum_block_5x": "Aluminium Block 5x",
+  "block.allthecompressed.aluminum_block_6x": "Aluminium Block 6x",
+  "block.allthecompressed.aluminum_block_7x": "Aluminium Block 7x",
+  "block.allthecompressed.aluminum_block_8x": "Aluminium Block 8x",
+  "block.allthecompressed.aluminum_block_9x": "Aluminium Block 9x"
+}


### PR DESCRIPTION
Change "Aluminum" to "Aluminium" in Australian and British locales.